### PR TITLE
bash-db bpkg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+install:
+	@if cp db.sh /usr/local/bin/db 2>/dev/null; then \
+		chmod +x /usr/local/bin/db; \
+		echo "Copied db.sh to /usr/local/bin/db"; \
+	elif echo $$PATH | grep -q "$$(realpath ~/.local/bin)"; then \
+		if [ ! -d ~/.local/bin ]; then \
+			echo "Creating directory ~/.local/bin"; \
+			mkdir -p ~/.local/bin; \
+		fi; \
+		cp db.sh ~/.local/bin/db; \
+		chmod +x ~/.local/bin/db; \
+		echo "Copied db.sh to ~/.local/bin/db"; \
+	else \
+		echo "Current PATH: $$PATH"; \
+		echo "Realpath of ~/.local/bin: $$(realpath ~/.local/bin)"; \
+		echo "Error: Could not copy db.sh to /usr/local/bin/db and ~/.local/bin is not in PATH."; \
+	fi;

--- a/README.md
+++ b/README.md
@@ -11,13 +11,28 @@ Very simple Key-Value database on bash script. Depends on pre-installed software
 Install
 =======
 
+### bpkg (global package)
 ```bash
+bpkg install reddec/bash-db
+```
+
+### Make (/usr/local/bin) 
+```bash
+make install
+``` 
+
+### Manual Installation 
+```bash
+git clone https://github.com/reddec/bash-db
+cd bash-db
 chmod +x db.sh
 cp db.sh /usr/local/bin/db
 ```
 
 Usage
 =======
+
+### Command-line Tool
 `db <method> <database> [arguments...]`
 
 Methods:

--- a/bpkg.json
+++ b/bpkg.json
@@ -1,0 +1,8 @@
+{
+  "name": "bash-db",
+  "version": "1.0.2",
+  "description": "Very simple Key-Value database on bash script",
+  "global": "true",
+  "scripts": [ "db.sh" ],
+  "install": "make install"
+}


### PR DESCRIPTION
**Draft PR. Needs work**


**TODO**
- [x] `Makefile` has an error
- [x] `README.md` probably needs a little work
- [x] Squash commits. 

**Commitment-Creep**
-  If versioned package management were desired, `reddec/bash-db` would need to use github tags/releases (otherwise `bpkg.json`'s can just use `master`
- Consider adding to `bpkg` package management repo.  [bpkg guidelines](https://bpkg.sh/guidelines) and [pkg submission](https://bpkg.sh/submit/)

**Improvements**

1. ~Can be sourced into bash scripts now~ Will do in another PR if this one is approved. 
2. Easier to write scripts that depend on `bash-db`

**Important**

Functionality is unchanged. 

**Testing criteria**

1. Install `bpkg` 
2. `bpkg install dskvr/bash-db` 
3. `db` 